### PR TITLE
chore: update arm_vgic dependency to crates.io version=0.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,4 @@ axdevice_base = "0.1"
 range-alloc = { git = "https://github.com/arceos-hypervisor/range-alloc.git" }
 
 [target.'cfg(target_arch = "aarch64")'.dependencies]
-arm_vgic = { git = "https://github.com/arceos-hypervisor/arm_vgic.git", features = ["vgicv3"] }
+arm_vgic = { version = "0.1", features = ["vgicv3"] }


### PR DESCRIPTION
Update arm_vgic dependency in axdevice to crates.io version=0.1

- Changed the arm_vgic dependency in axdevice from a Git repository to the crates.io version (0.1).
- This update ensures consistency with the arm_vgic dependency used in axvm.
- Previously, axdevice relied on a Git repository for arm_vgic, which could lead to version mismatches.
- Fixes https://github.com/arceos-hypervisor/axvisor/issues/321